### PR TITLE
HY-1827 - Set src/ as the lib directory for jspm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ script:
 # Encrypted SAUCE_USERNAME and SAUCE_ACCESS_KEY
 env:
   global:
-    - secure: Dx/Qyqu1kF56Z1Z4HI58O8iNZDt20cyyIMbmhYqIttDRpABi/KdwcmbitncRcHrwnmyEeDpaQgbtMgBXf/kNY/GWyd7+/SUbVsWDKNTDxFE7LDHPbAi+0cKsbdR1kseIepbfsVTRShei3+LqdaV1dI/gp56kubRBnIfTkGysMdw=
-    - secure: Vk+C0wnQmdYJgPiUw8IclfwfRE61tSn1OXSpZOxaxuaUpj51IovOuAGGg7dlPHJObKieXFDmd5qQ+y7JyAfTuv4ALEwyvXy2EkCUSMo8Nd4QvB0oW8D898vJllu5STCIBE8+58VQAm7bUq3WQ46fNaiGEY6fpgOfPSPWwjB1RZc=
+  - secure: jARZrMETm0//W5ysWpc8kiue/5NZlG1OWh30FoT34bTPqxQYPNOMcc7wIUe6dNSFZNsoaXBgfIAEoGcaw2yhNic8eBuTVRbKBPWrXuXHLp0b67zAj+UjpAuKv7wFSnbjse/i+rrUow17Hz9cU6qiAwWfvEXJoYYAg6+1srvbnFQ=
+  - secure: XG0F3ueV5Iolv60gUEJMqzPqBgyNpmo00DQ8HGpF7JxJp7ARkDvzpuY3Q7P00bATwVbV5S/MC/77rqvUVsLbN0Z3cpAt6SyS90fk+FoYkOkFWG498zDltSnaCsWnVe3J1v/d8Q2AE/mu1vCHTXVBpWlGLahy+yKK9f1mPlFM6Ss=

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,4 @@ before_install:
 install:
 - ./init.sh
 script:
-- grunt ci
-# Generated https://docs.saucelabs.com/ci-integrations/travis-ci/
-# Encrypted SAUCE_USERNAME and SAUCE_ACCESS_KEY
-env:
-  global:
-  - secure: jARZrMETm0//W5ysWpc8kiue/5NZlG1OWh30FoT34bTPqxQYPNOMcc7wIUe6dNSFZNsoaXBgfIAEoGcaw2yhNic8eBuTVRbKBPWrXuXHLp0b67zAj+UjpAuKv7wFSnbjse/i+rrUow17Hz9cU6qiAwWfvEXJoYYAg6+1srvbnFQ=
-  - secure: XG0F3ueV5Iolv60gUEJMqzPqBgyNpmo00DQ8HGpF7JxJp7ARkDvzpuY3Q7P00bATwVbV5S/MC/77rqvUVsLbN0Z3cpAt6SyS90fk+FoYkOkFWG498zDltSnaCsWnVe3J1v/d8Q2AE/mu1vCHTXVBpWlGLahy+yKK9f1mPlFM6Ss=
+- grunt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+- '0.10'
+before_install:
+- npm install -g bower
+- npm install -g grunt-cli
+install:
+- ./init.sh
+script:
+- grunt ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,9 @@ install:
 - ./init.sh
 script:
 - grunt ci
+# Generated https://docs.saucelabs.com/ci-integrations/travis-ci/
+# Encrypted SAUCE_USERNAME and SAUCE_ACCESS_KEY
+env:
+  global:
+    - secure: Dx/Qyqu1kF56Z1Z4HI58O8iNZDt20cyyIMbmhYqIttDRpABi/KdwcmbitncRcHrwnmyEeDpaQgbtMgBXf/kNY/GWyd7+/SUbVsWDKNTDxFE7LDHPbAi+0cKsbdR1kseIepbfsVTRShei3+LqdaV1dI/gp56kubRBnIfTkGysMdw=
+    - secure: Vk+C0wnQmdYJgPiUw8IclfwfRE61tSn1OXSpZOxaxuaUpj51IovOuAGGg7dlPHJObKieXFDmd5qQ+y7JyAfTuv4ALEwyvXy2EkCUSMo8Nd4QvB0oW8D898vJllu5STCIBE8+58VQAm7bUq3WQ46fNaiGEY6fpgOfPSPWwjB1RZc=

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "readmeFilename": "README.md",
   "devDependencies": {
     "grunt": "~0.4.1",
-    "wf-grunt": "git+ssh://git@github.com:WebFilings/wf-grunt.git#0.4.0"
+    "wf-grunt": "git+ssh://git@github.com:Workiva/wf-grunt.git#0.4.0"
   },
   "dependencies": {
     "connect": "^2.17.3",

--- a/package.json
+++ b/package.json
@@ -27,5 +27,10 @@
     "moment": "^2.6.0",
     "open": "0.0.5",
     "raw-body": "^1.1.6"
+  },
+  "jspm": {
+    "directories": {
+      "lib": "src"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "readmeFilename": "README.md",
   "devDependencies": {
     "grunt": "~0.4.1",
-    "wf-grunt": "git+ssh://git@github.com:Workiva/wf-grunt.git#0.4.0"
+    "wf-grunt": "git://github.com/Workiva/wf-grunt.git#0.4.0"
   },
   "dependencies": {
     "connect": "^2.17.3",


### PR DESCRIPTION
# Blocked - I assume I need to figure out the correct travis CI ssh credentials to embed in .travis.yml.

See http://docs.travis-ci.com/user/environment-variables/#Secure-Variables
# Problem

Since requireJS aliases are set to allow referencing files in src/, without typing src/, jspm consumers will get 404s when attempting to use the require() functions.
# Solution

Instruct jspm, via package.json, that src/ is the lib directory.  This change allows jspm to automagically work with the existing code, and those requireJS aliases. 
# How to Test

This is just a config change, so there is nothing to functionally test.
